### PR TITLE
refactor(maps): comment out simulated route overlay in MultiMapView

### DIFF
--- a/src/features/maps/components/MultiMapView.tsx
+++ b/src/features/maps/components/MultiMapView.tsx
@@ -101,9 +101,9 @@ const MultiMapView = ({ height = "100%", options = false }: MultiMapViewProps) =
                                 <div key={trip.code || i}>
                                     {showZones && (
                                         <Suspense fallback={<div>Cargando zonas...</div>}>
-                                            <Overlay checked name="Ruta Simulada">
+                                            {/* <Overlay checked name="Ruta Simulada">
                                                 <RouteLayer origenDestinyAsigned={[origenCoords, destinoCoords]} />
-                                            </Overlay>
+                                            </Overlay> */}
                                             <Overlay checked name={`Camión ${i + 1}`}>
                                                 <VehicleMarker origenDestinyAsigned={[origenCoords, destinoCoords]} simulated={false} />
                                             </Overlay>


### PR DESCRIPTION
The simulated route overlay was temporarily disabled to streamline the map view and reduce unnecessary visual clutter. This change focuses on displaying only the essential vehicle markers for improved clarity.