### PR TITLE
style(monitorings): adjust height in MapList component for better layout

### DIFF
--- a/src/features/monitorings/components/MapList.tsx
+++ b/src/features/monitorings/components/MapList.tsx
@@ -96,7 +96,7 @@ const MapList = ({ selectedTrips, selectedTripOD }: MapListProps) => {
                                     <div
                                         className="text-center w-full"
                                         style={{
-                                            height: selectedTripODAsArray.length <= 2 ? '750px' : '372px'
+                                            height: selectedTripODAsArray.length <= 2 ? '750px' : '395px'
                                         }}
                                     >
 
@@ -104,7 +104,7 @@ const MapList = ({ selectedTrips, selectedTripOD }: MapListProps) => {
                                             tripOrigin={[parseInt(ruta.ciudadOrigenLatitud), parseInt(ruta.ciudadOrigenLongitud)]}
                                             tripDestination={[parseInt(ruta.ciudadDestinoLatitud), parseInt(ruta.ciudadDestinoLongitud)]}
                                             origenDestinyAsigned={[[parseInt(ruta.ciudadOrigenLatitud), parseInt(ruta.ciudadOrigenLongitud)], [parseInt(ruta.ciudadDestinoLatitud), parseInt(ruta.ciudadDestinoLongitud)]]}
-                                            height={selectedTripODAsArray.length <= 2 ? '750px' : '372px'}
+                                            height={selectedTripODAsArray.length <= 2 ? '750px' : '395px'}
                                             nameCitys={[ruta.nameCiudadOrigen, " - ", ruta.nameCiudadDestino]}
                                         />
                                     </div>


### PR DESCRIPTION
The height of the map container was increased from 372px to 395px when there are more than 2 trip origins and destinations to improve the visual layout and avoid potential overflow issues.