### PR TITLE
chore: update allowedHosts in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,6 @@ export default defineConfig({
     // },
     host: "0.0.0.0",
     port: 5186,
-    allowedHosts: ["strack.iotlink.cl"],
+    allowedHosts: ["strack.wisensor.cl"],
   },
 });


### PR DESCRIPTION
Update the allowedHosts configuration to reflect the new domain "strack.wisensor.cl" for proper host validation